### PR TITLE
Upgrade base to core22, adjust build-packages accordingly

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: >
   configuration file interface to easily connect to TTY devices for basic I/O
   operations.
 
-base: core20
+base: core22
 grade: stable
 confinement: classic
 
@@ -25,6 +25,8 @@ parts:
     build-packages:
       - pkg-config
       - cmake
+      - meson
+      - ninja-build
       - bash-completion
       - liblua5.2-dev
       - libglib2.0-dev


### PR DESCRIPTION
1. Fixes https://github.com/tio/tio/issues/250 without removing provided here 2 packages by upgrading base from core20 to core22.
2. Makes tio snap buildable for core22+ as base.

Now it requires snapcraft 7.0+ to build a snap :)