### PR TITLE
Add auto-patching ELF files to fix rpaths. Found this when building locally

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -34,3 +34,5 @@ parts:
       - bash-completion
       - liblua5.2-0
       - libglib2.0-0
+    build-attributes:
+      - enable-patchelf


### PR DESCRIPTION
My previous PR which upgraded core to 22 and added 2 missing build deps, was missing auto-patching elfs.
I don't know how, but when remote-building, you don't see linting stage results, that rpaths are wrong, and resulting snap is working. This PR fixes that. Sorry!

Result from now:
```
khazakar@msi-bravo-15:~/Projects/tio.snapcraft$ snap install tio --channel=latest/edge --classic
tio (edge) 3.4 from Martin Lund (lundmar) installed
khazakar@msi-bravo-15:~/Projects/tio.snapcraft$ tio
/snap/tio/1112/usr/bin/tio: error while loading shared libraries: liblua5.2.so.0: cannot open shared object file: No such file or directory
```
Result after fix:
```
khazakar@msi-bravo-15:~/Projects/tio.snapcraft$ snap install tio_3.4_amd64.snap --dangerous --classic 
tio 3.4 installed
khazakar@msi-bravo-15:~/Projects/tio.snapcraft$ tio
Usage: tio [<options>] <tty-device|profile|tid>
[...]
```